### PR TITLE
Update QR code quality

### DIFF
--- a/O3/Extensions/UIImage.swift
+++ b/O3/Extensions/UIImage.swift
@@ -9,7 +9,7 @@
 import UIKit
 extension UIImage {
     convenience init(qrData: String, width: CGFloat, height: CGFloat) {
-        let filterQR = CIFilter(name: "CIQRCodeGenerator", withInputParameters: ["inputMessage": qrData.data(using: .utf8) ?? Data(), "inputCorrectionLevel": "L"])
+        let filterQR = CIFilter(name: "CIQRCodeGenerator", withInputParameters: ["inputMessage": qrData.data(using: .utf8) ?? Data(), "inputCorrectionLevel": "H"])
         guard let ciImageQR = filterQR?.outputImage else {
             self.init()
             return


### PR DESCRIPTION
The input correction level was set to low, so there was less room for error on scans. By increasing this level to high, we are able to get faster and more reliant scans, and retain the O3 logo in the middle with no alteration.