### PR TITLE
Add NEP9 QR code parsing to send screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+
+.DS_Store

--- a/O3.xcodeproj/project.pbxproj
+++ b/O3.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		014B532D20BFEE7A00F6967C /* neoutils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 014B532C20BFEE7A00F6967C /* neoutils.framework */; };
 		350100F220441B53000F6648 /* CurrencyTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 350100F120441B53000F6648 /* CurrencyTableViewController.swift */; };
 		350100F4204541A6000F6648 /* SwiftTheme.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 350100F3204541A6000F6648 /* SwiftTheme.framework */; };
 		350100F5204541A6000F6648 /* SwiftTheme.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 350100F3204541A6000F6648 /* SwiftTheme.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -241,6 +242,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		014B532C20BFEE7A00F6967C /* neoutils.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = neoutils.framework; sourceTree = "<group>"; };
 		350100F120441B53000F6648 /* CurrencyTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyTableViewController.swift; sourceTree = "<group>"; };
 		350100F3204541A6000F6648 /* SwiftTheme.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftTheme.framework; path = Carthage/Build/iOS/SwiftTheme.framework; sourceTree = "<group>"; };
 		35051B131FFDAD9200F9AD30 /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fabric.framework; path = Carthage/Build/iOS/Fabric.framework; sourceTree = "<group>"; };
@@ -296,7 +298,6 @@
 		3557BACE20AA9D300034937C /* Array+Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Util.swift"; sourceTree = "<group>"; };
 		3557BACF20AA9D300034937C /* NEP9.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEP9.swift; sourceTree = "<group>"; };
 		3557BAD120AA9D310034937C /* Data+Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Util.swift"; sourceTree = "<group>"; };
-		3557BAD920AA9F690034937C /* neoutils.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = neoutils.framework; sourceTree = "<group>"; };
 		3557BADD20AAA0940034937C /* O3-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "O3-Bridging-Header.h"; sourceTree = "<group>"; };
 		3557BAE020AAA32F0034937C /* ValueIn.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueIn.swift; sourceTree = "<group>"; };
 		3557BAE120AAA32F0034937C /* ValueOut.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueOut.swift; sourceTree = "<group>"; };
@@ -449,6 +450,7 @@
 				350100F4204541A6000F6648 /* SwiftTheme.framework in Frameworks */,
 				6E244EC020858AB8001B4B22 /* Lottie.framework in Frameworks */,
 				35494575203C030A00332E53 /* Tabman.framework in Frameworks */,
+				014B532D20BFEE7A00F6967C /* neoutils.framework in Frameworks */,
 				3549456D203BF1F700332E53 /* Pageboy.framework in Frameworks */,
 				6E97C4B91F7FCB4000526FF0 /* DeckTransition.framework in Frameworks */,
 				35051B1C1FFDB10800F9AD30 /* Crashlytics.framework in Frameworks */,
@@ -709,7 +711,7 @@
 		755D8F5E1F66743900058434 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				3557BAD920AA9F690034937C /* neoutils.framework */,
+				014B532C20BFEE7A00F6967C /* neoutils.framework */,
 				351200BA207DE0E2003CA07D /* StoreKit.framework */,
 				3549456B203BF0A400332E53 /* Foundation.framework */,
 				35A6390E203517BB0054EA20 /* CloudKit.framework */,

--- a/O3/New Group/Util/NEP9.swift
+++ b/O3/New Group/Util/NEP9.swift
@@ -11,7 +11,7 @@ import Neoutils
 
 public class NEP9 {
     public typealias NEP9 = NeoutilsSimplifiedNEP9
-    public func parse(uri: String) -> NEP9? {
+    public static func parse(_ uri: String) -> NEP9? {
         var error: NSError?
         guard let uri = NeoutilsParseNEP9URI(uri, &error) else { return nil }
         return uri

--- a/O3/Send/SendTableViewController.swift
+++ b/O3/Send/SendTableViewController.swift
@@ -252,9 +252,9 @@ class SendTableViewController: UITableViewController, AddressSelectDelegate, QRS
             if asset != "" {
                 var selected: TransferableAsset?
                 
-                if (asset?.lowercased() == "neo") {
+                if (asset?.lowercased() == "neo" || asset == AssetId.neoAssetId.rawValue) {
                     selected = O3Cache.neo()
-                } else if (asset?.lowercased() == "gas") {
+                } else if (asset?.lowercased() == "gas" || asset == AssetId.gasAssetId.rawValue) {
                     selected = O3Cache.gas()
                 } else {
                     let tokenAssets = O3Cache.tokenAssets()

--- a/O3/Send/SendTableViewController.swift
+++ b/O3/Send/SendTableViewController.swift
@@ -237,39 +237,44 @@ class SendTableViewController: UITableViewController, AddressSelectDelegate, QRS
     }
 
     func qrScanned(data: String) {
-        let nep9Data = NEP9.parse(data)
-        let address = nep9Data?.to()
-        let asset = nep9Data?.asset()
-        let amount = nep9Data?.amount()
         
-        toAddressField.text = address
-        
-        
-        if asset != "" {
-            var selected: TransferableAsset?
+        if data.range(of:"neo:") == nil {
+            toAddressField.text = data
+        } else {
+            let nep9Data = NEP9.parse(data)
+            let address = nep9Data?.to()
+            let asset = nep9Data?.asset()
+            let amount = nep9Data?.amount()
             
-            if (asset?.lowercased() == "neo") {
-                selected = O3Cache.neo()
-            } else if (asset?.lowercased() == "gas") {
-                selected = O3Cache.gas()
-            } else {
-                let tokenAssets = O3Cache.tokenAssets()
-                let assetIndex = tokenAssets.index(where: { (item) -> Bool in
-                    item.id.range(of:asset!) != nil
-                })
-                if assetIndex != nil {
-                    selected = tokenAssets[assetIndex!]
+            toAddressField.text = address
+            
+            
+            if asset != "" {
+                var selected: TransferableAsset?
+                
+                if (asset?.lowercased() == "neo") {
+                    selected = O3Cache.neo()
+                } else if (asset?.lowercased() == "gas") {
+                    selected = O3Cache.gas()
+                } else {
+                    let tokenAssets = O3Cache.tokenAssets()
+                    let assetIndex = tokenAssets.index(where: { (item) -> Bool in
+                        item.id.range(of:asset!) != nil
+                    })
+                    if assetIndex != nil {
+                        selected = tokenAssets[assetIndex!]
+                    }
+                }
+                
+                if selected != nil {
+                    self.selectedAsset = selected
+                    self.selectedAssetLabel.text = selected!.symbol
                 }
             }
-     
-            if selected != nil {
-                self.selectedAsset = selected
-                self.selectedAssetLabel.text = selected!.symbol
+            
+            if amount != nil {
+                self.amountField.text = String(format:"%f",amount!)
             }
-        }
-        
-        if amount != nil {
-            self.amountField.text = String(format:"%f",amount!)
         }
         
         enableSendButton()

--- a/O3/Send/SendTableViewController.swift
+++ b/O3/Send/SendTableViewController.swift
@@ -237,7 +237,41 @@ class SendTableViewController: UITableViewController, AddressSelectDelegate, QRS
     }
 
     func qrScanned(data: String) {
-        toAddressField.text = data
+        let nep9Data = NEP9.parse(data)
+        let address = nep9Data?.to()
+        let asset = nep9Data?.asset()
+        let amount = nep9Data?.amount()
+        
+        toAddressField.text = address
+        
+        
+        if asset != "" {
+            var selected: TransferableAsset?
+            
+            if (asset?.lowercased() == "neo") {
+                selected = O3Cache.neo()
+            } else if (asset?.lowercased() == "gas") {
+                selected = O3Cache.gas()
+            } else {
+                let tokenAssets = O3Cache.tokenAssets()
+                let assetIndex = tokenAssets.index(where: { (item) -> Bool in
+                    item.id.range(of:asset!) != nil
+                })
+                if assetIndex != nil {
+                    selected = tokenAssets[assetIndex!]
+                }
+            }
+     
+            if selected != nil {
+                self.selectedAsset = selected
+                self.selectedAssetLabel.text = selected!.symbol
+            }
+        }
+        
+        if amount != nil {
+            self.amountField.text = String(format:"%f",amount!)
+        }
+        
         enableSendButton()
     }
 

--- a/neoutils.framework/Versions/A/Headers/Neoutils.objc.h
+++ b/neoutils.framework/Versions/A/Headers/Neoutils.objc.h
@@ -13,6 +13,7 @@
 @class NeoutilsBlockCountResponse;
 @class NeoutilsFetchSeedRequest;
 @class NeoutilsMultiSig;
+@class NeoutilsNEP2;
 @class NeoutilsNEP5;
 @class NeoutilsNativeAsset;
 @class NeoutilsNodeList;
@@ -95,6 +96,18 @@
 
 // skipped method MultiSig.CreateMultiSignedAddress with unsupported parameter or return types
 
+@end
+
+@interface NeoutilsNEP2 : NSObject <goSeqRefInterface> {
+}
+@property(strong, readonly) id _ref;
+
+- (instancetype)initWithRef:(id)ref;
+- (instancetype)init;
+- (NSString*)encryptedKey;
+- (void)setEncryptedKey:(NSString*)v;
+- (NSString*)address;
+- (void)setAddress:(NSString*)v;
 @end
 
 @interface NeoutilsNEP5 : NSObject <goSeqRefInterface, NeoutilsNEP5Interface> {
@@ -181,8 +194,8 @@
 - (instancetype)init;
 - (NSString*)to;
 - (void)setTo:(NSString*)v;
-- (NSString*)assetID;
-- (void)setAssetID:(NSString*)v;
+- (NSString*)asset;
+- (void)setAsset:(NSString*)v;
 - (double)amount;
 - (void)setAmount:(double)v;
 @end
@@ -247,11 +260,12 @@ FOUNDATION_EXPORT NSData* NeoutilsHexTobytes(NSString* hexstring);
 
 FOUNDATION_EXPORT NeoutilsRawTransaction* NeoutilsMintTokensRawTransactionMobile(NSString* network, NSString* scriptHash, NSString* wif, NSString* sendingAssetID, double amount, NSString* remark, double networkFeeAmountInGAS, NSError** error);
 
-FOUNDATION_EXPORT NSString* NeoutilsNEOAddressToScriptHash(NSString* neoAddress);
+// skipped function NEOAddressToScriptHashWithEndian with unsupported parameter or return types
+
 
 FOUNDATION_EXPORT NSString* NeoutilsNEP2Decrypt(NSString* key, NSString* passphrase, NSError** error);
 
-FOUNDATION_EXPORT NSString* NeoutilsNEP2Encrypt(NSString* wif, NSString* passphrase, NSError** error);
+FOUNDATION_EXPORT NeoutilsNEP2* NeoutilsNEP2Encrypt(NSString* wif, NSString* passphrase, NSError** error);
 
 FOUNDATION_EXPORT NeoutilsWallet* NeoutilsNewWallet(NSError** error);
 


### PR DESCRIPTION
This PR addresses issue:
https://github.com/O3Labs/OzoneWalletIOS/issues/46

The QR code scanner on the send screen can now parse NEP9 URI into fields. It is also still backwards compatible with just scanning an address for legacy clients.

Scans work for neo, gas, and nep5. If you scan a URI requesting an asset that is not in your wallet, the asset input field is not updated.

Test with https://o3.network/nep9/

Updated neoutils as well to get latest NEP9 standard